### PR TITLE
feat: 공통 예외 처리

### DIFF
--- a/src/main/java/com/bb3/bodybuddybe/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/bb3/bodybuddybe/common/dto/ApiResponseDto.java
@@ -1,0 +1,20 @@
+package com.bb3.bodybuddybe.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponseDto {
+    private Integer statusCode;
+    private String message;
+
+    public ApiResponseDto(Integer statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/bb3/bodybuddybe/common/exception/CustomException.java
+++ b/src/main/java/com/bb3/bodybuddybe/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.bb3.bodybuddybe.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/bb3/bodybuddybe/common/exception/ErrorCode.java
+++ b/src/main/java/com/bb3/bodybuddybe/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.bb3.bodybuddybe.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // 예시)
+    // USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U001", "존재하지 않는 사용자입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/bb3/bodybuddybe/common/exception/ErrorResponse.java
+++ b/src/main/java/com/bb3/bodybuddybe/common/exception/ErrorResponse.java
@@ -1,0 +1,47 @@
+package com.bb3.bodybuddybe.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private String code;
+    private String message;
+
+    public static ErrorResponse of(String code, String message) {
+        return ErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse of(String code, BindingResult bindingResult) {
+        return ErrorResponse.builder()
+                .code(code)
+                .message(createErrorMessage(bindingResult))
+                .build();
+    }
+
+    private static String createErrorMessage(BindingResult bindingResult) {
+        StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        for(FieldError fieldError : fieldErrors) {
+            if(!isFirst) {
+                sb.append(", ");
+            } else {
+                isFirst = false;
+            }
+            sb.append("[");
+            sb.append(fieldError.getField());
+            sb.append("] ");
+            sb.append(fieldError.getDefaultMessage());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/bb3/bodybuddybe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bb3/bodybuddybe/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.bb3.bodybuddybe.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // javax.validation.Valid binding error 발생한 경우
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getBindingResult());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    // @RequestParam enum 으로 binding 되지 못한 경우
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    // 지원하지 않는 HTTP method 호출하는 경우
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
+    // 비즈니스 로직 실행 중 에러 발생하는 경우
+    @ExceptionHandler(value = CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    // 그 외 예외 발생하는 경우
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}


### PR DESCRIPTION
## Issue #4 
## 변경 사항
*  비지니스 에러를 위해 `CustomException` 클래스를 작성하였습니다.
*  `ErrorCode` enum 클래스를 만들어 커스텀 예외를 손쉽게 관리하도록 했습니다.
*  `GlobalExceptionHandler`를 통해 모든 예외를 한 곳에서 처리하였습니다.
*  에러가 발생하지 않고 Service 클래스에서 void 리턴할 경우 사용할 수 있는 공통 응답 dto인 `ApiResponseDto`를 작성하였습니다.