### PR TITLE
hotfix: 로그인 시 인증 헤더가 없는 문제 해결

### DIFF
--- a/src/main/java/com/bb3/bodybuddybe/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/bb3/bodybuddybe/common/config/WebSecurityConfig.java
@@ -67,6 +67,7 @@ public class WebSecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
         configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization")); // Authorization 헤더 노출
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/**", configuration);


### PR DESCRIPTION
## Issue #40 
## 변경 사항
* `WebSecurityConfig`에 응답 헤더 설정을 추가하여 인증 헤더가 노출될 수 있도록 조치하였습니다.

> `configuration.setAllowedHeaders()` → 요청 헤더 허용
> `configuration.setExposedHeaders()` → 응답 헤더 허용